### PR TITLE
use US Locale for date format

### DIFF
--- a/src/main/java/io/vertx/ext/apex/addons/impl/StaticServerImpl.java
+++ b/src/main/java/io/vertx/ext/apex/addons/impl/StaticServerImpl.java
@@ -34,6 +34,7 @@ import io.vertx.ext.apex.core.RoutingContext;
 import io.vertx.ext.apex.core.impl.LRUCache;
 import io.vertx.ext.apex.core.impl.Utils;
 
+import java.io.File;
 import java.nio.file.NoSuchFileException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -390,7 +391,7 @@ public class StaticServerImpl implements StaticServer {
           StringBuilder files = new StringBuilder("<ul id=\"files\">");
 
           for (String s : asyncResult.result()) {
-            file = s.substring(s.lastIndexOf('/') + 1);
+            file = s.substring(s.lastIndexOf(File.separatorChar) + 1);
             // skip dot files
             if (!includeHidden && file.charAt(0) == '.') {
               continue;
@@ -438,7 +439,7 @@ public class StaticServerImpl implements StaticServer {
           JsonArray json = new JsonArray();
 
           for (String s : asyncResult.result()) {
-            file = s.substring(s.lastIndexOf('/') + 1);
+            file = s.substring(s.lastIndexOf(File.separatorChar) + 1);
             // skip dot files
             if (!includeHidden && file.charAt(0) == '.') {
               continue;
@@ -452,7 +453,7 @@ public class StaticServerImpl implements StaticServer {
           StringBuilder buffer = new StringBuilder();
 
           for (String s : asyncResult.result()) {
-            file = s.substring(s.lastIndexOf('/') + 1);
+            file = s.substring(s.lastIndexOf(File.separatorChar) + 1);
             // skip dot files
             if (!includeHidden && file.charAt(0) == '.') {
               continue;

--- a/src/main/java/io/vertx/ext/apex/core/impl/Utils.java
+++ b/src/main/java/io/vertx/ext/apex/core/impl/Utils.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -115,7 +116,7 @@ public class Utils {
   }
 
   public static DateFormat createISODateTimeFormatter() {
-    DateFormat dtf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+    DateFormat dtf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
     dtf.setTimeZone(TimeZone.getTimeZone("UTC"));
     return dtf;
   }

--- a/src/test/java/io/vertx/ext/apex/addons/test/BodiesTest.java
+++ b/src/test/java/io/vertx/ext/apex/addons/test/BodiesTest.java
@@ -169,7 +169,7 @@ public class BodiesTest extends ApexTestBase {
       // FIXME Add test in core test suite to validated this!
       // assertEquals(fileData.length(), upload.size());
       String uploadedFileName = upload.uploadedFileName();
-      assertTrue(uploadedFileName.startsWith(uploadsDir + "/"));
+      assertTrue(uploadedFileName.startsWith(uploadsDir + File.separator));
       Buffer uploaded = vertx.fileSystem().readFileBlocking(uploadedFileName);
       assertEquals(fileData, uploaded);
       // The body should be set too


### PR DESCRIPTION
use File.separator instead of "/" in some places to make the tests work in Windows
use File.separator in directory browser, otherwise we get the complete path as link in Windows

Signed-off-by: alexlehm <alexlehm@gmail.com>