### PR TITLE
Avoid exception in ctMatches when no Content-Type sent

### DIFF
--- a/src/main/java/io/vertx/ext/apex/impl/RouteImpl.java
+++ b/src/main/java/io/vertx/ext/apex/impl/RouteImpl.java
@@ -285,6 +285,10 @@ public class RouteImpl implements Route {
       return true;
     }
 
+    if (actualCT == null) {
+      return false;
+    }
+    
     // get the content type only (exclude charset)
     actualCT = actualCT.split(";")[0];
 

--- a/src/test/java/io/vertx/ext/apex/RouterTest.java
+++ b/src/test/java/io/vertx/ext/apex/RouterTest.java
@@ -747,6 +747,12 @@ public class RouterTest extends ApexTestBase {
   }
 
   @Test
+  public void testConsumesNoContentType() throws Exception {
+    router.route().consumes("text/html").handler(rc -> rc.response().end());
+    testRequest(HttpMethod.GET, "/foo", 404, "Not Found");
+  }
+
+  @Test
   public void testProduces() throws Exception {
     router.route().produces("text/html").handler(rc -> rc.response().end());
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 200, "OK");


### PR DESCRIPTION
Check Content-Type is not null before trying to match it with the accepted content types

Fixes #53