### PR TITLE
get access to cache settings

### DIFF
--- a/src/main/java/io/vertx/ext/apex/templ/ThymeleafTemplateEngine.java
+++ b/src/main/java/io/vertx/ext/apex/templ/ThymeleafTemplateEngine.java
@@ -1,17 +1,9 @@
 /*
- * Copyright 2014 Red Hat, Inc.
- *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
- *
- *  The Eclipse Public License is available at
- *  http://www.eclipse.org/legal/epl-v10.html
- *
- *  The Apache License v2.0 is available at
- *  http://www.opensource.org/licenses/apache2.0.php
- *
- *  You may elect to redistribute this code under either of these licenses.
+ * Copyright 2014 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v1.0 and Apache License v2.0 which accompanies this distribution. The
+ * Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available
+ * at http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.ext.apex.templ;
@@ -32,7 +24,7 @@ public interface ThymeleafTemplateEngine extends TemplateEngine {
   /**
    * Create a template engine using defaults
    *
-   * @return  the engine
+   * @return the engine
    */
   static ThymeleafTemplateEngine create() {
     return new ThymeleafTemplateEngineImpl();
@@ -41,9 +33,28 @@ public interface ThymeleafTemplateEngine extends TemplateEngine {
   /**
    * Set the mode for the engine
    *
-   * @param mode  the mode
+   * @param mode
+   *          the mode
    * @return a reference to this for fluency
    */
   ThymeleafTemplateEngine setMode(String mode);
+
+  /**
+   * Set the overall cacheability for underlaying engine
+   *
+   * @param cachable
+   *          activate / deactivate the cache
+   * @return a reference to this for fluency
+   */
+  ThymeleafTemplateEngine setCacheable(boolean cacheable);
+
+  /**
+   * Set the cache time of the underlaying engine
+   *
+   * @param cacheTTLMs
+   *          the cacheTTLMs
+   * @return a reference to this for fluency
+   */
+  ThymeleafTemplateEngine setCacheTTLMs(Long cacheTTLMs);
 
 }

--- a/src/main/java/io/vertx/ext/apex/templ/ThymeleafTemplateEngine.java
+++ b/src/main/java/io/vertx/ext/apex/templ/ThymeleafTemplateEngine.java
@@ -11,6 +11,8 @@ package io.vertx.ext.apex.templ;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.ext.apex.templ.impl.ThymeleafTemplateEngineImpl;
 
+import org.thymeleaf.templateresolver.TemplateResolver;
+
 /**
  * A template engine that uses the Thymeleaf library.
  *
@@ -40,21 +42,10 @@ public interface ThymeleafTemplateEngine extends TemplateEngine {
   ThymeleafTemplateEngine setMode(String mode);
 
   /**
-   * Set the overall cacheability for underlaying engine
-   *
-   * @param cachable
-   *          activate / deactivate the cache
-   * @return a reference to this for fluency
+   * Retrieve the template resolver to be able to access the settings of Thymeleaf
+   * 
+   * @return
    */
-  ThymeleafTemplateEngine setCacheable(boolean cacheable);
-
-  /**
-   * Set the cache time of the underlaying engine
-   *
-   * @param cacheTTLMs
-   *          the cacheTTLMs
-   * @return a reference to this for fluency
-   */
-  ThymeleafTemplateEngine setCacheTTLMs(Long cacheTTLMs);
+  public TemplateResolver getTemplateResolver();
 
 }

--- a/src/main/java/io/vertx/ext/apex/templ/impl/ThymeleafTemplateEngineImpl.java
+++ b/src/main/java/io/vertx/ext/apex/templ/impl/ThymeleafTemplateEngineImpl.java
@@ -87,6 +87,15 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
     }
   }
 
+  /**
+   * Return the underlaying Thymeleaf engine for further configuration
+   * 
+   * @return
+   */
+  public TemplateEngine getEngine(){
+	return engine;  
+  }
+  
   /*
    We extend VariablesMap to avoid copying all context map data for each render
    We put the context data Map directly into the variable map and we also provide

--- a/src/main/java/io/vertx/ext/apex/templ/impl/ThymeleafTemplateEngineImpl.java
+++ b/src/main/java/io/vertx/ext/apex/templ/impl/ThymeleafTemplateEngineImpl.java
@@ -1,26 +1,31 @@
 /*
- * Copyright 2014 Red Hat, Inc.
- *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
- *
- *  The Eclipse Public License is available at
- *  http://www.eclipse.org/legal/epl-v10.html
- *
- *  The Apache License v2.0 is available at
- *  http://www.opensource.org/licenses/apache2.0.php
- *
- *  You may elect to redistribute this code under either of these licenses.
+ * Copyright 2014 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v1.0 and Apache License v2.0 which accompanies this distribution. The
+ * Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available
+ * at http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.ext.apex.templ.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.apex.RoutingContext;
 import io.vertx.ext.apex.impl.Utils;
 import io.vertx.ext.apex.templ.ThymeleafTemplateEngine;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.util.Locale;
+
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.TemplateProcessingParameters;
 import org.thymeleaf.context.IContext;
@@ -28,16 +33,13 @@ import org.thymeleaf.context.VariablesMap;
 import org.thymeleaf.resourceresolver.IResourceResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
 
-import java.io.*;
-import java.util.Locale;
-
 /**
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
 
-  private final TemplateEngine engine = new TemplateEngine();
+  private final TemplateEngine   engine   = new TemplateEngine();
   private final TemplateResolver templateResolver;
   private final ResourceResolver resolver = new ResourceResolver();
 
@@ -87,24 +89,32 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
     }
   }
 
-  /**
-   * Return the underlaying Thymeleaf engine for further configuration
-   * 
-   * @return
-   */
-  public TemplateEngine getEngine(){
-	return engine;  
-  }
-  
   /*
-   We extend VariablesMap to avoid copying all context map data for each render
-   We put the context data Map directly into the variable map and we also provide
-   variables called:
-   _context - this is the routing context itself
-   _request - this is the HttpServerRequest object
-   _response - this is the HttpServerResponse object
-    */
-  private static class ApexIContext implements IContext  {
+   * (non-Javadoc)
+   * @see io.vertx.ext.apex.templ.ThymeleafTemplateEngine#setCacheable(boolean)
+   */
+  @Override
+  public ThymeleafTemplateEngine setCacheable(boolean cacheable) {
+    templateResolver.setCacheable(cacheable);
+    return this;
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see io.vertx.ext.apex.templ.ThymeleafTemplateEngine#setCacheTTLMs(java.lang.Long)
+   */
+  @Override
+  public ThymeleafTemplateEngine setCacheTTLMs(Long cacheTTLMs) {
+    templateResolver.setCacheTTLMs(cacheTTLMs);
+    return this;
+  }
+
+  /*
+   * We extend VariablesMap to avoid copying all context map data for each render We put the context data Map directly
+   * into the variable map and we also provide variables called: _context - this is the routing context itself _request
+   * - this is the HttpServerRequest object _response - this is the HttpServerResponse object
+   */
+  private static class ApexIContext implements IContext {
 
     private final VariablesMap<String, Object> data;
 
@@ -142,7 +152,8 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
     }
 
     @Override
-    public InputStream getResourceAsStream(TemplateProcessingParameters templateProcessingParameters, String resourceName) {
+    public InputStream getResourceAsStream(TemplateProcessingParameters templateProcessingParameters,
+        String resourceName) {
       String str = Utils.readFileToString(vertx, resourceName);
       try {
         ByteArrayInputStream bis = new ByteArrayInputStream(str.getBytes("UTF-8"));
@@ -153,8 +164,5 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
       }
     }
   }
-
-
-
 
 }

--- a/src/main/java/io/vertx/ext/apex/templ/impl/ThymeleafTemplateEngineImpl.java
+++ b/src/main/java/io/vertx/ext/apex/templ/impl/ThymeleafTemplateEngineImpl.java
@@ -91,22 +91,11 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
 
   /*
    * (non-Javadoc)
-   * @see io.vertx.ext.apex.templ.ThymeleafTemplateEngine#setCacheable(boolean)
+   * @see io.vertx.ext.apex.templ.ThymeleafTemplateEngine#getTemplateResolver()
    */
   @Override
-  public ThymeleafTemplateEngine setCacheable(boolean cacheable) {
-    templateResolver.setCacheable(cacheable);
-    return this;
-  }
-
-  /*
-   * (non-Javadoc)
-   * @see io.vertx.ext.apex.templ.ThymeleafTemplateEngine#setCacheTTLMs(java.lang.Long)
-   */
-  @Override
-  public ThymeleafTemplateEngine setCacheTTLMs(Long cacheTTLMs) {
-    templateResolver.setCacheTTLMs(cacheTTLMs);
-    return this;
+  public TemplateResolver getTemplateResolver() {
+    return templateResolver;
   }
 
   /*

--- a/src/test/java/io/vertx/ext/apex/templ/ThymeleafTemplateTest.java
+++ b/src/test/java/io/vertx/ext/apex/templ/ThymeleafTemplateTest.java
@@ -1,33 +1,24 @@
 /*
- * Copyright 2014 Red Hat, Inc.
- *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
- *
- *  The Eclipse Public License is available at
- *  http://www.eclipse.org/legal/epl-v10.html
- *
- *  The Apache License v2.0 is available at
- *  http://www.opensource.org/licenses/apache2.0.php
- *
- *  You may elect to redistribute this code under either of these licenses.
+ * Copyright 2014 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v1.0 and Apache License v2.0 which accompanies this distribution. The
+ * Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available
+ * at http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.ext.apex.templ;
 
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.apex.handler.TemplateHandler;
 import io.vertx.ext.apex.ApexTestBase;
+import io.vertx.ext.apex.handler.TemplateHandler;
+
 import org.junit.Test;
 
 /**
- *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class ThymeleafTemplateTest extends ApexTestBase {
 
-	
   @Test
   public void testTemplateHandlerOnClasspath() throws Exception {
     TemplateEngine engine = ThymeleafTemplateEngine.create();
@@ -42,12 +33,11 @@ public class ThymeleafTemplateTest extends ApexTestBase {
 
   @Test
   public void testTemplateHandlerUncached() throws Exception {
-	ThymeleafTemplateEngine engine = ThymeleafTemplateEngine.create();
-    engine.setCacheable( false );
+    ThymeleafTemplateEngine engine = ThymeleafTemplateEngine.create();
+    engine.getTemplateResolver().setCacheable(false);
     testTemplateHandler(engine, "somedir", "test-thymeleaf-template2.html");
   }
 
-  
   private void testTemplateHandler(TemplateEngine engine, String directoryName, String templateName) throws Exception {
     router.route().handler(context -> {
       context.put("foo", "badger");
@@ -55,21 +45,21 @@ public class ThymeleafTemplateTest extends ApexTestBase {
       context.next();
     });
     router.route().handler(TemplateHandler.create(engine, directoryName, "text/html"));
-    String expected =
-      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n" +
-        "\n" +
-        "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
-        "<head>\n" +
-        "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
-        "</head>\n" +
-        "<body>\n" +
-        "<p>badger</p>\n" +
-        "<p>fox</p>\n" +
-        "<p>/" + templateName + "</p>\n" +
-        "<p>blah</p>\n" +
-        "<p>wibble</p>\n" +
-        "</body>\n" +
-        "</html>";
+    String expected = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+        + "\n"
+        + "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+        + "<head>\n"
+        + "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n"
+        + "</head>\n"
+        + "<body>\n"
+        + "<p>badger</p>\n"
+        + "<p>fox</p>\n"
+        + "<p>/"
+        + templateName
+        + "</p>\n"
+        + "<p>blah</p>\n"
+        + "<p>wibble</p>\n"
+        + "</body>\n" + "</html>";
 
     testRequest(HttpMethod.GET, "/" + templateName + "?param1=blah&param2=wibble", 200, "OK", expected);
   }

--- a/src/test/java/io/vertx/ext/apex/templ/ThymeleafTemplateTest.java
+++ b/src/test/java/io/vertx/ext/apex/templ/ThymeleafTemplateTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
  */
 public class ThymeleafTemplateTest extends ApexTestBase {
 
+	
   @Test
   public void testTemplateHandlerOnClasspath() throws Exception {
     TemplateEngine engine = ThymeleafTemplateEngine.create();
@@ -39,6 +40,14 @@ public class ThymeleafTemplateTest extends ApexTestBase {
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-thymeleaf-template3.html");
   }
 
+  @Test
+  public void testTemplateHandlerUncached() throws Exception {
+	ThymeleafTemplateEngine engine = ThymeleafTemplateEngine.create();
+    engine.setCacheable( false );
+    testTemplateHandler(engine, "somedir", "test-thymeleaf-template2.html");
+  }
+
+  
   private void testTemplateHandler(TemplateEngine engine, String directoryName, String templateName) throws Exception {
     router.route().handler(context -> {
       context.put("foo", "badger");


### PR DESCRIPTION
added methods to modify the cache settings of the TemplateResolver. Since those settings can only be done before initialization, i think its the better way than accessing the Resolver directly.
Added simple test method to check, that processing works as normal. 
