### PR TITLE
Fix typo on Sub-routers chapter

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -858,7 +858,7 @@ mainRouter.mountSubRouter("/productsAPI", restAPI)
 
 ----
 
-This means the REST API is not accessible via paths like: `/productsAPI/products/product1234`
+This means the REST API is now accessible via paths like: `/productsAPI/products/product1234`
 
 == Default 404 Handling
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -774,7 +774,7 @@ We can now mount the sub router on the main router, against a mount point, in th
 mainRouter.mountSubRouter("/productsAPI", restAPI);
 ----
 
-This means the REST API is not accessible via paths like: `/productsAPI/products/product1234`
+This means the REST API is now accessible via paths like: `/productsAPI/products/product1234`
 
 == Default 404 Handling
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -853,7 +853,7 @@ mainRouter.mountSubRouter("/productsAPI", restAPI);
 
 ----
 
-This means the REST API is not accessible via paths like: `/productsAPI/products/product1234`
+This means the REST API is now accessible via paths like: `/productsAPI/products/product1234`
 
 == Default 404 Handling
 

--- a/src/main/java/io/vertx/ext/apex/package-info.java
+++ b/src/main/java/io/vertx/ext/apex/package-info.java
@@ -483,7 +483,7 @@
  * {@link examples.Examples#example24}
  * ----
  *
- * This means the REST API is not accessible via paths like: `/productsAPI/products/product1234`
+ * This means the REST API is now accessible via paths like: `/productsAPI/products/product1234`
  *
  * == Default 404 Handling
  *


### PR DESCRIPTION
Replaced misleading typo: "is not accessible" by "is now accessible".