### PR TITLE
Add /* when routes really need to match the whole path.

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -266,7 +266,7 @@ With any path it can also be specified when creating the route:
 [source,groovy]
 ----
 
-def route = router.route("/some/path/")
+def route = router.route("/some/path/*")
 
 route.handler({ routingContext ->
   // This handler will be called same as previous example
@@ -842,7 +842,7 @@ import io.vertx.groovy.ext.apex.Router
 def mainRouter = Router.router(vertx)
 
 // Handle static resources
-mainRouter.route("/static").handler(myStaticHandler)
+mainRouter.route("/static/*").handler(myStaticHandler)
 
 mainRouter.route(".*\\.templ").handler(myTemplateHandler)
 
@@ -883,7 +883,7 @@ to paths that start with `/somepath/`:
 [source,groovy]
 ----
 
-def route = router.get("/somepath/")
+def route = router.get("/somepath/*")
 
 route.failureHandler({ frc ->
 
@@ -927,7 +927,7 @@ route2.handler({ routingContext ->
 
 // Define a failure handler
 // This will get called for any failures in the above handlers
-def route3 = router.get("/somepath/")
+def route3 = router.get("/somepath/*")
 
 route3.failureHandler({ failureRoutingContext ->
 
@@ -1351,7 +1351,7 @@ def authService = AuthService.createEventBusProxy(vertx, "acme.authservice")
 def basicAuthHandler = BasicAuthHandler.create(authService)
 
 // All requests to paths starting with '/private/' will be protected
-router.route("/private/").handler(basicAuthHandler)
+router.route("/private/*").handler(basicAuthHandler)
 
 router.route("/someotherpath").handler({ routingContext ->
 
@@ -1432,7 +1432,7 @@ def authService = AuthService.createEventBusProxy(vertx, "acme.authservice")
 def redirectAuthHandler = RedirectAuthHandler.create(authService)
 
 // All requests to paths starting with '/private/' will be protected
-router.route("/private/").handler(redirectAuthHandler)
+router.route("/private/*").handler(redirectAuthHandler)
 
 // Handle the actual login
 router.route("/login").handler(FormLoginHandler.create(authService))
@@ -1506,7 +1506,7 @@ In the following example all requests to paths starting with `/static/` will get
 ----
 import io.vertx.groovy.ext.apex.handler.StaticHandler
 
-router.route("/static/").handler(StaticHandler.create())
+router.route("/static/*").handler(StaticHandler.create())
 
 
 ----

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -250,7 +250,7 @@ With any path it can also be specified when creating the route:
 
 [source,java]
 ----
-Route route = router.route("/some/path/");
+Route route = router.route("/some/path/*");
 
 route.handler(routingContext -> {
   // This handler will be called same as previous example
@@ -762,7 +762,7 @@ However, let's say we already have a web-site as described by another router:
 Router mainRouter = Router.router(vertx);
 
 // Handle static resources
-mainRouter.route("/static").handler(myStaticHandler);
+mainRouter.route("/static/*").handler(myStaticHandler);
 
 mainRouter.route(".*\\.templ").handler(myTemplateHandler);
 ----
@@ -798,7 +798,7 @@ to paths that start with `/somepath/`:
 
 [source,java]
 ----
-Route route = router.get("/somepath/");
+Route route = router.get("/somepath/*");
 
 route.failureHandler(frc -> {
 
@@ -840,7 +840,7 @@ route2.handler(routingContext -> {
 
 // Define a failure handler
 // This will get called for any failures in the above handlers
-Route route3 = router.get("/somepath/");
+Route route3 = router.get("/somepath/*");
 
 route3.failureHandler(failureRoutingContext -> {
 
@@ -1193,7 +1193,7 @@ AuthService authService = AuthService.createEventBusProxy(vertx, "acme.authservi
 AuthHandler basicAuthHandler = BasicAuthHandler.create(authService);
 
 // All requests to paths starting with '/private/' will be protected
-router.route("/private/").handler(basicAuthHandler);
+router.route("/private/*").handler(basicAuthHandler);
 
 router.route("/someotherpath").handler(routingContext -> {
 
@@ -1265,7 +1265,7 @@ AuthService authService = AuthService.createEventBusProxy(vertx, "acme.authservi
 AuthHandler redirectAuthHandler = RedirectAuthHandler.create(authService);
 
 // All requests to paths starting with '/private/' will be protected
-router.route("/private/").handler(redirectAuthHandler);
+router.route("/private/*").handler(redirectAuthHandler);
 
 // Handle the actual login
 router.route("/login").handler(FormLoginHandler.create(authService));
@@ -1331,7 +1331,7 @@ In the following example all requests to paths starting with `/static/` will get
 
 [source,java]
 ----
-router.route("/static/").handler(StaticHandler.create());
+router.route("/static/*").handler(StaticHandler.create());
 ----
 
 For example, if there was a request with path `/static/css/mystyles.css` the static serve will look for a file in the

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -266,7 +266,7 @@ With any path it can also be specified when creating the route:
 [source,js]
 ----
 
-var route = router.route("/some/path/");
+var route = router.route("/some/path/*");
 
 route.handler(function (routingContext) {
   // This handler will be called same as previous example
@@ -837,7 +837,7 @@ var Router = require("vertx-apex-js/router");
 var mainRouter = Router.router(vertx);
 
 // Handle static resources
-mainRouter.route("/static").handler(myStaticHandler);
+mainRouter.route("/static/*").handler(myStaticHandler);
 
 mainRouter.route(".*\\.templ").handler(myTemplateHandler);
 
@@ -878,7 +878,7 @@ to paths that start with `/somepath/`:
 [source,js]
 ----
 
-var route = router.get("/somepath/");
+var route = router.get("/somepath/*");
 
 route.failureHandler(function (frc) {
 
@@ -922,7 +922,7 @@ route2.handler(function (routingContext) {
 
 // Define a failure handler
 // This will get called for any failures in the above handlers
-var route3 = router.get("/somepath/");
+var route3 = router.get("/somepath/*");
 
 route3.failureHandler(function (failureRoutingContext) {
 
@@ -1346,7 +1346,7 @@ var authService = AuthService.createEventBusProxy(vertx, "acme.authservice");
 var basicAuthHandler = BasicAuthHandler.create(authService);
 
 // All requests to paths starting with '/private/' will be protected
-router.route("/private/").handler(basicAuthHandler.handle);
+router.route("/private/*").handler(basicAuthHandler.handle);
 
 router.route("/someotherpath").handler(function (routingContext) {
 
@@ -1427,7 +1427,7 @@ var authService = AuthService.createEventBusProxy(vertx, "acme.authservice");
 var redirectAuthHandler = RedirectAuthHandler.create(authService);
 
 // All requests to paths starting with '/private/' will be protected
-router.route("/private/").handler(redirectAuthHandler.handle);
+router.route("/private/*").handler(redirectAuthHandler.handle);
 
 // Handle the actual login
 router.route("/login").handler(FormLoginHandler.create(authService).handle);
@@ -1501,7 +1501,7 @@ In the following example all requests to paths starting with `/static/` will get
 ----
 var StaticHandler = require("vertx-apex-js/static_handler");
 
-router.route("/static/").handler(StaticHandler.create().handle);
+router.route("/static/*").handler(StaticHandler.create().handle);
 
 
 ----

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -107,7 +107,7 @@ public class Examples {
 
   public void example4(Router router) {
 
-    Route route = router.route("/some/path/");
+    Route route = router.route("/some/path/*");
 
     route.handler(routingContext -> {
       // This handler will be called same as previous example
@@ -471,7 +471,7 @@ public class Examples {
     Router mainRouter = Router.router(vertx);
 
     // Handle static resources
-    mainRouter.route("/static").handler(myStaticHandler);
+    mainRouter.route("/static/*").handler(myStaticHandler);
 
     mainRouter.route(".*\\.templ").handler(myTemplateHandler);
   }
@@ -484,7 +484,7 @@ public class Examples {
 
   public void example25(Router router) {
 
-    Route route = router.get("/somepath/");
+    Route route = router.get("/somepath/*");
 
     route.failureHandler(frc -> {
 
@@ -518,7 +518,7 @@ public class Examples {
 
     // Define a failure handler
     // This will get called for any failures in the above handlers
-    Route route3 = router.get("/somepath/");
+    Route route3 = router.get("/somepath/*");
 
     route3.failureHandler(failureRoutingContext -> {
 
@@ -699,7 +699,7 @@ public class Examples {
     AuthHandler basicAuthHandler = BasicAuthHandler.create(authService);
 
     // All requests to paths starting with '/private/' will be protected
-    router.route("/private/").handler(basicAuthHandler);
+    router.route("/private/*").handler(basicAuthHandler);
 
     router.route("/someotherpath").handler(routingContext -> {
 
@@ -726,7 +726,7 @@ public class Examples {
     AuthHandler redirectAuthHandler = RedirectAuthHandler.create(authService);
 
     // All requests to paths starting with '/private/' will be protected
-    router.route("/private/").handler(redirectAuthHandler);
+    router.route("/private/*").handler(redirectAuthHandler);
 
     // Handle the actual login
     router.route("/login").handler(FormLoginHandler.create(authService));
@@ -767,7 +767,7 @@ public class Examples {
 
   public void example41(Router router) {
 
-    router.route("/static/").handler(StaticHandler.create());
+    router.route("/static/*").handler(StaticHandler.create());
 
   }
   public void example41_0_1(Router router) {


### PR DESCRIPTION
Example:
mainRouter.route("/static") -> mainRouter.route("/static/")
The documentation doesn't reflect what's in the vertx-example repo code.