### PR TITLE
SessionImpl class is not serializable so fails in clustered session store.

### DIFF
--- a/src/main/java/io/vertx/ext/apex/impl/SessionImpl.java
+++ b/src/main/java/io/vertx/ext/apex/impl/SessionImpl.java
@@ -58,9 +58,9 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   private static final byte TYPE_SERIALIZABLE = 12;
   private static final byte TYPE_CLUSTER_SERIALIZABLE = 13;
 
-  private final String id;
-  private final SessionStore sessionStore;
-  private final long timeout;
+  private String id;
+  private SessionStore sessionStore;
+  private long timeout;
   private Map<String, Object> data;
 
   private long lastAccessed;
@@ -69,6 +69,10 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   private AuthService authService;
   private Set<String> roles = new HashSet<>();
   private Set<String> permissions = new HashSet<>();
+
+  public SessionImpl()
+  {
+  }
 
   public SessionImpl(String id, long timeout, SessionStore sessionStore) {
     this.id = id;
@@ -245,6 +249,9 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   @Override
   public Buffer writeToBuffer() {
     Buffer buff = Buffer.buffer();
+    buff.appendInt(id.length());
+    buff.appendString(id);
+    buff.appendLong(timeout);
     buff.appendLong(lastAccessed);
     Buffer dataBuf = writeDataToBuffer();
     buff.appendInt(dataBuf.length());
@@ -255,9 +262,15 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   @Override
   public void readFromBuffer(Buffer buffer) {
     int pos = 0;
+    int len = buffer.getInt(pos);
+    pos += 4;
+    id = buffer.getString(pos, pos + len);
+    pos += len;
+    timeout = buffer.getLong(pos);
+    pos += 8;
     lastAccessed = buffer.getLong(pos);
     pos += 8;
-    int len = buffer.getInt(pos);
+    len = buffer.getInt(pos);
     pos += 4;
     data = readDataFromBuffer(buffer, pos);
   }


### PR DESCRIPTION
The SessionImpl class is not serializable because is lacks a zero argument constructor. This means that it causes an exception when using sessions with a ClusteredSessionStore. The serialised form created by the writeToBuffer() method does not include the "timeout" field (which results in sessions being discarded as soon as they are referenced from the store) or the "id" field which appears to be needed, although, I did not identify exactly where. I have updated the SessionImpl class to overcome these problems.