### PR TITLE
Set this.path in RouteImpl also for dynamic routes

### DIFF
--- a/src/main/java/io/vertx/ext/apex/impl/RouteImpl.java
+++ b/src/main/java/io/vertx/ext/apex/impl/RouteImpl.java
@@ -358,6 +358,7 @@ public class RouteImpl implements Route {
     // a regex for that
     if (path.indexOf(':') != -1) {
       createPatternRegex(path);
+      this.path = path;
     } else {
       if (path.charAt(path.length() - 1) != '*') {
         exactPath = true;

--- a/src/test/java/io/vertx/ext/apex/RouterTest.java
+++ b/src/test/java/io/vertx/ext/apex/RouterTest.java
@@ -54,7 +54,7 @@ public class RouterTest extends ApexTestBase {
   }
   
   @Test
-  public void testGetPath() throws Exception {
+  public void testRouteGetPath() throws Exception {
     assertEquals("/foo", router.route("/foo").getPath());
     assertEquals("/foo/:id", router.route("/foo/:id").getPath());
   }

--- a/src/test/java/io/vertx/ext/apex/RouterTest.java
+++ b/src/test/java/io/vertx/ext/apex/RouterTest.java
@@ -52,6 +52,12 @@ public class RouterTest extends ApexTestBase {
       // OK
     }
   }
+  
+  @Test
+  public void testGetPath() throws Exception {
+    assertEquals("/foo", router.route("/foo").getPath());
+    assertEquals("/foo/:id", router.route("/foo/:id").getPath());
+  }
 
   @Test
   public void testRoutePathAndMethod() throws Exception {


### PR DESCRIPTION
Without this fix getPath() always returns null for dynamic routes (i.e. routes with path parameters).